### PR TITLE
Fix annotation/formatting errors in xho/train.txt

### DIFF
--- a/MasakhaNER2.0/data/xho/train.txt
+++ b/MasakhaNER2.0/data/xho/train.txt
@@ -44517,7 +44517,6 @@ u O
 ' O
 Ndiyekeni O
 , O
- O
 uNdila B-PER
 uthuma O
 uFuneka B-PER
@@ -74510,7 +74509,6 @@ plagiarism O
 ) O
 ' O
 kunye O
- O
 nokukopa O
 . O
 ' O


### PR DESCRIPTION
I noticed there are two lines with empty annotations in the xho/train.txt data for MasakhaNER. I've removed the two lines with empty annotations.